### PR TITLE
Fix CLIENT_SECRET environment variable name

### DIFF
--- a/src/entra-id-cca-session/auth/EntraIdServerAuthProvider.ts
+++ b/src/entra-id-cca-session/auth/EntraIdServerAuthProvider.ts
@@ -27,7 +27,7 @@ export class EntraIdServerAuthProvider implements OAuthServerProvider {
     constructor() {
         dotenv.config();
 
-        const requiredEnvVars = ['FR_TENANT_ID', 'FR_PUBLIC_CLIENT_ID', 'FR_API_CLIENT_ID'];
+        const requiredEnvVars = ['FR_TENANT_ID', 'FR_API_CLIENT_SECRET', 'FR_API_CLIENT_ID'];
 
         const missingEnvVars = requiredEnvVars.filter(varName => !process.env[varName]);
         if (missingEnvVars.length > 0) {


### PR DESCRIPTION
## Purpose
* `CLIENT_SECRET` variable name is wrong in `EntraIdServerAuthProvider.ts`

```
npm run start

> simple-mcp-server@0.0.1 start
> node dist/Server.js

file:///mcp-auth-servers/src/entra-id-cca-session/dist/auth/EntraIdServerAuthProvider.js:23
            throw new Error(`Missing required environment variables: ${missingEnvVars.join(', ')}`);
                  ^

Error: Missing required environment variables: FR_PUBLIC_CLIENT_ID
    at new EntraIdServerAuthProvider (file:///mcp-auth-servers/src/entra-id-cca-session/dist/auth/EntraIdServerAuthProvider.js:23:19)
    at file:///mcp-auth-servers/src/entra-id-cca-session/dist/Server.js:11:18

Node.js v24.1.0
```

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code

```
cd src/entra-id-cca-session
npm run build
npm run start
```

* Test the code

## What to Check

No error should happen : 

```
npm run start

> simple-mcp-server@0.0.1 start
> node dist/Server.js

Server is running on port 3001
Loaded 1 registered clients from file.
```
